### PR TITLE
Add `objArrEquals`

### DIFF
--- a/.changeset/flat-cars-prove.md
+++ b/.changeset/flat-cars-prove.md
@@ -1,0 +1,5 @@
+---
+"@bryx-inc/ts-utils": minor
+---
+
+Add objArrayEquals

--- a/src/array.test.ts
+++ b/src/array.test.ts
@@ -16,6 +16,7 @@ import {
     lastElem,
     mergeArrs,
     moveToIdx,
+    objArrEquals,
     objectifyArr,
     permutationsOf,
     repeat,
@@ -428,5 +429,33 @@ describe("findAndSpliceArr", () => {
         const splicedElements = findAndSpliceArr(arr, (el) => el == 1);
         expect(arr).toEqual([]);
         expect(splicedElements).toEqual([]);
+    });
+});
+
+describe("objArrEquals", () => {
+    it("should return true if the arrays are equal", () => {
+        const arr1 = [
+            { id: 1, name: "joe" },
+            { id: 2, name: "jane" },
+        ];
+        const arr2 = [
+            { id: 2, name: "jane" },
+            { id: 1, name: "joe" },
+        ];
+        const equal = objArrEquals(arr1, arr2, "id");
+        expect(equal).toEqual(true);
+    });
+
+    it("should return false if the arrays are not equal", () => {
+        const arr1 = [
+            { id: 1, name: "joe" },
+            { id: 2, name: "jane" },
+        ];
+        const arr2 = [
+            { id: 2, name: "jane" },
+            { id: 3, name: "joe" },
+        ];
+        const equal = objArrEquals(arr1, arr2, "id");
+        expect(equal).toEqual(false);
     });
 });

--- a/src/array.test.ts
+++ b/src/array.test.ts
@@ -458,4 +458,14 @@ describe("objArrEquals", () => {
         const equal = objArrEquals(arr1, arr2, "id");
         expect(equal).toEqual(false);
     });
+
+    it("should return false if the arrays are different lengths", () => {
+        const arr1 = [
+            { id: 1, name: "joe" },
+            { id: 2, name: "jane" },
+        ];
+        const arr2 = [{ id: 2, name: "jane" }];
+        const equal = objArrEquals(arr1, arr2, "id");
+        expect(equal).toEqual(false);
+    });
 });

--- a/src/array.ts
+++ b/src/array.ts
@@ -679,20 +679,22 @@ export function findAndSpliceArr<T>(arr: T[], pred: (el: T, i?: number) => boole
 }
 
 /**
- * Returns a boolean value indicating whether or not two arrays of objects are equal regardless or order.
- * 
+ * Determine the equality of two object arrays by checking if each value at the given key of the
+ * first array is present in the second array at the same key.
+ * If the given arrays are of different length, return false.
+ *
  * @param arr1 - The first array to compare.
  * @param arr2 - The second array to compare.
  * @param key - The key to compare the objects by.
  * @returns A boolean value indicating whether or not the two arrays are equal.
- * 
+ *
  * @example
  * ```ts
  * const arr1 = [{ id: 1, name: "joe" }, { id: 2, name: "jane" }];
  * const arr2 = [{ id: 2, name: "jane" }, { id: 1, name: "joe" }];
  * const equal = objArrEquals(arr1, arr2, "id");
  * console.log(equal); // Output: true
- * 
+ *
  * @category Array
  */
 export function objArrEquals<T extends object, K extends keyof T>(arr1: T[], arr2: T[], key: K): boolean {

--- a/src/array.ts
+++ b/src/array.ts
@@ -677,3 +677,25 @@ export function findAndSpliceArr<T>(arr: T[], pred: (el: T, i?: number) => boole
     if (idx < 0) return [];
     return arr.splice(idx, cnt);
 }
+
+/**
+ * Returns a boolean value indicating whether or not two arrays of objects are equal regardless or order.
+ * 
+ * @param arr1 - The first array to compare.
+ * @param arr2 - The second array to compare.
+ * @param key - The key to compare the objects by.
+ * @returns A boolean value indicating whether or not the two arrays are equal.
+ * 
+ * @example
+ * ```ts
+ * const arr1 = [{ id: 1, name: "joe" }, { id: 2, name: "jane" }];
+ * const arr2 = [{ id: 2, name: "jane" }, { id: 1, name: "joe" }];
+ * const equal = objArrEquals(arr1, arr2, "id");
+ * console.log(equal); // Output: true
+ * 
+ * @category Array
+ */
+export function objArrEquals<T extends object, K extends keyof T>(arr1: T[], arr2: T[], key: K): boolean {
+    if (arr1.length !== arr2.length) return false;
+    return arr1.every((el) => arr2.some((el2) => el[key] === el2[key]));
+}

--- a/typedoc-dist/.nojekyll
+++ b/typedoc-dist/.nojekyll
@@ -1,1 +1,0 @@
-TypeDoc added this file to prevent GitHub Pages from using Jekyll. You can turn off this behavior by setting the `githubPages` option to false.

--- a/typedoc-dist/.nojekyll
+++ b/typedoc-dist/.nojekyll
@@ -1,0 +1,1 @@
+TypeDoc added this file to prevent GitHub Pages from using Jekyll. You can turn off this behavior by setting the `githubPages` option to false.


### PR DESCRIPTION
Added a function that takes in two arrays and returns a boolean value determining if the two arrays are equal. This is better than the common method of `JSON.stringify(arr1) !== JSON.stringify(arr2)` since it ignores the order of the elements.