### PR TITLE
Optional Mapping for `WrappedMaybe['take']`

### DIFF
--- a/.changeset/early-mirrors-drive.md
+++ b/.changeset/early-mirrors-drive.md
@@ -1,0 +1,8 @@
+---
+"@bryx-inc/ts-utils": minor
+---
+
+-   Make `WrappedMaybe<T>` methods chainable
+    -   `value()` renamed to `take()`
+    -   `takeIf` and `takeUnless` do not chain
+    -   chainable `if` and `unless` methods introduced

--- a/.changeset/lazy-eels-approve.md
+++ b/.changeset/lazy-eels-approve.md
@@ -1,0 +1,5 @@
+---
+"@bryx-inc/ts-utils": minor
+---
+
+WrappedMaybe: allow optional mapping to be passed to `take`

--- a/src/maybe.test.ts
+++ b/src/maybe.test.ts
@@ -234,6 +234,14 @@ describe("maybe()", () => {
         expect(maybe(thing2)?.take()).toEqual(undefined);
     });
 
+    it("should properly call the mapping and eject the wrapped value", () => {
+        const thing = "foo" as Maybe<string>;
+        const thing2 = null as Maybe<string>;
+
+        expect(maybe(thing)?.take((it) => it.length)).toEqual(3);
+        expect(maybe(thing2)?.take((it) => it.length)).toEqual(undefined);
+    });
+
     it('should handle "also" method correctly', () => {
         const thing = "foo" as Maybe<string>;
         const thing2 = null as Maybe<string>;

--- a/src/maybe.test.ts
+++ b/src/maybe.test.ts
@@ -185,7 +185,7 @@ describe("take()", () => {
 describe("maybe()", () => {
     it("should allow chaining methods and return the wrapped value", () => {
         const wrappedValue = maybe(42);
-        const result = wrappedValue.let((it) => it * 2);
+        const result = wrappedValue.let((it) => it * 2).take();
 
         expect(result).toBe(84);
     });
@@ -204,12 +204,34 @@ describe("maybe()", () => {
         expect(maybe([] as number[] | null)?.takeIf((it) => it.length > 0)).toEqual(null);
     });
 
+    it('should handle "if" method correctly', () => {
+        expect(
+            maybe([1, 2, 3] as number[] | null)
+                ?.if((it) => it.length > 0)
+                ?.take(),
+        ).toEqual([1, 2, 3]);
+        expect(
+            maybe([1, 2, 3] as number[] | null)
+                ?.if((it) => it.length == 0)
+                ?.take(),
+        ).toEqual(undefined);
+    });
+
+    it('should handle "unless" method correctly', () => {
+        expect(
+            maybe([1, 2, 3] as number[] | null)
+                ?.unless((it) => it.length == 0)
+                ?.take(),
+        ).toEqual([1, 2, 3]);
+        expect(maybe([] as number[] | null)?.unless((it) => it.length == 0)).toEqual(maybe(null));
+    });
+
     it("should properly eject the wrapped value", () => {
         const thing = "foo" as Maybe<string>;
         const thing2 = null as Maybe<string>;
 
-        expect(maybe(thing)?.value()).toEqual("foo");
-        expect(maybe(thing2)?.value).toEqual(undefined);
+        expect(maybe(thing)?.take()).toEqual("foo");
+        expect(maybe(thing2)?.take()).toEqual(undefined);
     });
 
     it('should handle "also" method correctly', () => {
@@ -219,17 +241,21 @@ describe("maybe()", () => {
         const fn = jest.fn();
 
         expect(
-            maybe(thing)?.also((it) => {
-                fn(it);
-                return "bar";
-            }),
+            maybe(thing)
+                ?.also((it) => {
+                    fn(it);
+                    return "bar";
+                })
+                .take(),
         ).toEqual("foo");
 
         expect(
-            maybe(thing2)?.also((it) => {
-                fn(it);
-                return "bar";
-            }),
+            maybe(thing2)
+                ?.also((it) => {
+                    fn(it);
+                    return "bar";
+                })
+                .take(),
         ).toEqual(undefined);
 
         expect(fn).toBeCalledTimes(1);

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -397,20 +397,20 @@ type NullOrUndefined = null | undefined;
 type WrappedMaybe<T> = T extends NullOrUndefined
     ? WrappedMaybe<Exclude<T, NullOrUndefined>> | Extract<T, NullOrUndefined>
     : {
-          /** Calls the specified function with the wrapped value as its argument and returns the result */
+          /** Calls the specified mapping with the wrapped value as its argument and returns the result */
           let: <E>(fn: (it: T) => E) => WrappedMaybe<E>;
           /** Calls the specified function with the wrapped value as its argument and returns the wrapped value */
           also: (fn: (it: T) => void) => WrappedMaybe<T>;
           /** Returns the taken value if it satisfies the given predicate, otherwise returns null */
-          takeIf: (predicate: (it: T) => boolean) => NonNullable<T> | null;
+          takeIf: (predicate: (it: T) => boolean) => T | null;
           /** Returns the taken value unless it satisfies the given predicate, in which case it returns null */
           takeUnless: (predicate: (it: T) => boolean) => T | null;
           /** Returns the wrapped value unless it satisfies the given predicate, in which case it returns null */
-          if: (predicate: (it: T) => boolean) => WrappedMaybe<NonNullable<T>> | null;
+          if: (predicate: (it: T) => boolean) => WrappedMaybe<T> | null;
           /** Returns the wrapped value unless it satisfies the given predicate, in which case it returns null */
-          unless: (predicate: (it: T) => boolean) => WrappedMaybe<NonNullable<T>> | null;
-          /** Returns the wrapped value it was called with */
-          take: () => NonNullable<T>;
+          unless: (predicate: (it: T) => boolean) => WrappedMaybe<T> | null;
+          /** Returns the wrapped value it was called with. A mapping may also be passed to mimic the behavor of `.let(fn).take()` */
+          take: <E = T>(fn?: (it: T) => E) => E;
       } & NonNullable<T>;
 
 /**
@@ -428,7 +428,7 @@ export function maybe<T>(wrapped: T): WrappedMaybe<T> {
             takeUnless: (predicate: (it: T) => boolean) => (predicate(wrapped) ? null : wrapped),
             if: (predicate: (it: T) => boolean) => maybe(predicate(wrapped) ? wrapped : null),
             unless: (predicate: (it: T) => boolean) => maybe(predicate(wrapped) ? null : wrapped),
-            take: () => wrapped,
+            take: <E = T>(fn?: (it: T) => E) => (typeof fn == "function" ? fn(wrapped) : wrapped),
             also: (fn: (it: T) => void) => {
                 fn(wrapped);
                 return maybe(wrapped);


### PR DESCRIPTION
- feat(maybe): make `maybe()` methods chain, expect for `take*` methods
- feat(maybe): allow a mapping to optionally be passed to `maybe().take`
